### PR TITLE
Fix missing absl includes

### DIFF
--- a/maldoca/base/BUILD.bazel
+++ b/maldoca/base/BUILD.bazel
@@ -94,6 +94,7 @@ cc_library(
         ":logging",
         ":status",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/maldoca/base/get_runfiles_dir.cc
+++ b/maldoca/base/get_runfiles_dir.cc
@@ -15,6 +15,7 @@
 #include "maldoca/base/get_runfiles_dir.h"
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "maldoca/base/logging.h"
 #include "maldoca/base/status_macros.h"
 

--- a/maldoca/service/BUILD.bazel
+++ b/maldoca/service/BUILD.bazel
@@ -236,10 +236,12 @@ cc_library(
             ":processing_component",
             "//maldoca/pdf_parser:adobe_api_mapper",
             "//maldoca/pdf_parser:pdfium_processor",
+            "@com_google_absl//absl/strings",
         ],
         "//:chrome_build": [
             ":office_processing_component",
             ":processing_component",
+            "@com_google_absl//absl/strings",
         ],
     }),
 )

--- a/maldoca/service/common/processing_component_factory.cc
+++ b/maldoca/service/common/processing_component_factory.cc
@@ -14,6 +14,7 @@
 
 #include "maldoca/service/common/processing_component_factory.h"
 
+#include "absl/strings/str_cat.h"
 #include "maldoca/service/common/office_processing_component.h"
 
 #ifndef MALDOCA_CHROME


### PR DESCRIPTION
Current code silently relies on transitive includes that are removed in the latest version of absl